### PR TITLE
Inject custom client as a parameter rather than type casting

### DIFF
--- a/sqls/schema.sql
+++ b/sqls/schema.sql
@@ -235,6 +235,19 @@ JOIN
 chars C
 ON U.wid = C.wid;
 
+-- Trigger to allow deletions from this table
+CREATE OR REPLACE FUNCTION delete_all_user_chars() RETURNS trigger AS $$
+BEGIN
+    DELETE FROM user_chars WHERE uid = OLD.uid AND wid = OLD.wid;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER delete_from_all_user_chars
+INSTEAD OF DELETE ON all_user_chars
+FOR EACH ROW
+EXECUTE PROCEDURE delete_all_user_chars();
+
 -- Helper to get all chars of a user
 -- Is this overkill?
 CREATE OR REPLACE FUNCTION get_user_chars(uuid bigint)

--- a/src/classes/client.ts
+++ b/src/classes/client.ts
@@ -11,27 +11,27 @@ import type { Cache } from '@modules/database';
 export function isSlashSubcommand(obj: any): obj is SlashSubcommand {
     return obj && obj.data instanceof SlashCommandSubcommandBuilder &&
         typeof obj.desc === 'string' && typeof obj.execute === 'function' &&
-        obj.execute.length === 2;
+        obj.execute.length <= 2;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isSlashSubcommandGroup(obj: any): obj is SlashSubcommandGroup {
     return obj && obj.data instanceof SlashCommandSubcommandGroupBuilder &&
         typeof obj.desc === 'string' && typeof obj.execute === 'function' &&
-        obj.subcommands && obj.execute.length === 2;
+        obj.subcommands && obj.execute.length <= 2;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isSlashCommand(obj: any): obj is SlashCommand {
     return obj && obj.data instanceof SlashCommandBuilder &&
         typeof obj.desc === 'string' && typeof obj.execute === 'function' &&
-        obj.execute.length === 2;
+        obj.execute.length <= 2;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isContextCommand(obj: any): obj is ContextCommand {
     return obj && obj.data instanceof ContextMenuCommandBuilder &&
-        typeof obj.execute === 'function' && obj.execute.length === 2;
+        typeof obj.execute === 'function' && obj.execute.length <= 2;
 }
 
 export function isInteractionCommand(obj: unknown): obj is InteractionCommand {

--- a/src/classes/client.ts
+++ b/src/classes/client.ts
@@ -11,27 +11,27 @@ import type { Cache } from '@modules/database';
 export function isSlashSubcommand(obj: any): obj is SlashSubcommand {
     return obj && obj.data instanceof SlashCommandSubcommandBuilder &&
         typeof obj.desc === 'string' && typeof obj.execute === 'function' &&
-        obj.execute.length === 1;
+        obj.execute.length === 2;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isSlashSubcommandGroup(obj: any): obj is SlashSubcommandGroup {
     return obj && obj.data instanceof SlashCommandSubcommandGroupBuilder &&
         typeof obj.desc === 'string' && typeof obj.execute === 'function' &&
-        obj.subcommands && obj.execute.length === 1;
+        obj.subcommands && obj.execute.length === 2;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isSlashCommand(obj: any): obj is SlashCommand {
     return obj && obj.data instanceof SlashCommandBuilder &&
         typeof obj.desc === 'string' && typeof obj.execute === 'function' &&
-        obj.execute.length === 1;
+        obj.execute.length === 2;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isContextCommand(obj: any): obj is ContextCommand {
     return obj && obj.data instanceof ContextMenuCommandBuilder &&
-        typeof obj.execute === 'function' && obj.execute.length === 1;
+        typeof obj.execute === 'function' && obj.execute.length === 2;
 }
 
 export function isInteractionCommand(obj: unknown): obj is InteractionCommand {
@@ -40,8 +40,8 @@ export function isInteractionCommand(obj: unknown): obj is InteractionCommand {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isMessageCommand(obj: any): obj is MessageCommand {
-    return obj && typeof obj.name === 'string' &&
-        typeof obj.execute === 'function' && obj.execute.length <= 2;
+    return obj && typeof obj.name === 'string' && typeof obj.admin === 'boolean' &&
+        typeof obj.desc === 'string' && typeof obj.execute === 'function' && obj.execute.length <= 3;
 }
 
 export type CommandFile = {
@@ -57,17 +57,17 @@ export interface MessageCommand {
     name: string;
     admin: boolean;
     desc: string;
-    execute: (msg: DTypes.Message & { readonly client: CustomClient }, args: string[]) => Promise<unknown>;
+    execute: (msg: DTypes.Message, args: string[], client: CustomClient) => Promise<unknown>;
 }
 
 // Basics that every slash command must have
 interface Command {
     data: DTypes.SlashCommandBuilder | DTypes.SlashCommandSubcommandBuilder | DTypes.SlashCommandSubcommandGroupBuilder;
     desc: string; // Long description for help command
-    execute: (i: DTypes.ChatInputCommandInteraction & { readonly client: CustomClient; }) => Promise<unknown>;
-    buttonReact?: (i: DTypes.ButtonInteraction & { readonly client: CustomClient }) => Promise<unknown>;
-    menuReact?: (i: DTypes.AnySelectMenuInteraction & { readonly client: CustomClient }) => Promise<unknown>;
-    textInput?: (i: DTypes.ModalSubmitInteraction & { readonly client: CustomClient }) => Promise<unknown>;
+    execute: (i: DTypes.ChatInputCommandInteraction, client: CustomClient) => Promise<unknown>;
+    buttonReact?: (i: DTypes.ButtonInteraction, client: CustomClient) => Promise<unknown>;
+    menuReact?: (i: DTypes.AnySelectMenuInteraction, client: CustomClient) => Promise<unknown>;
+    textInput?: (i: DTypes.ModalSubmitInteraction, client: CustomClient) => Promise<unknown>;
 }
 export interface SlashSubcommand extends Command {
     data: DTypes.SlashCommandSubcommandBuilder;
@@ -89,7 +89,7 @@ export type CachedSlashSubcommandGroup<T extends object> = SlashCommand & CacheD
 // Basics that every context command must have
 export interface ContextCommand {
     data: DTypes.ContextMenuCommandBuilder;
-    execute: (i: DTypes.ContextMenuCommandInteraction & { readonly client: CustomClient; }) => Promise<unknown>;
+    execute: (i: DTypes.ContextMenuCommandInteraction, client: CustomClient) => Promise<unknown>;
 }
 
 export type InteractionCommand = SlashCommand | ContextCommand;
@@ -100,7 +100,7 @@ export class CustomClient extends Client {
     // Predefine custom properties
     is_ready!: boolean;                              // Is fully loaded
     is_listening!: boolean;                          // Is currently listening for interactions
-    prefix!: string;                                 // Message prefix
+    readonly prefix!: string;                        // Message prefix
     admin!: DTypes.User;                             // Admin user
     log_channel!: DTypes.TextBasedChannel;           // Error logs
     bot_emojis!: Record<string, string>;             // All available emojis

--- a/src/commands/admin_commands.ts
+++ b/src/commands/admin_commands.ts
@@ -154,7 +154,7 @@ export const purge: MessageCommand & PurgePrivates = {
             }).catch(() => { });
     },
 
-    async execute(message, args) {
+    async execute(message, args, client) {
         // Defaults to 100
         let amount = 100;
         let all = false;
@@ -198,7 +198,7 @@ export const purge: MessageCommand & PurgePrivates = {
             return message.reply({ content: 'No messages to delete.' });
         }
 
-        if (amount >= 100 && message.author.id !== message.client.admin.id) {
+        if (amount >= 100 && message.author.id !== client.admin.id) {
             const buttonMessage = await message.reply({
                 content: "Woah! That's a lot of messages!\nAre you sure " +
                     `you want to delete ${amount} messages?`,
@@ -286,7 +286,7 @@ export const add: MessageCommand = {
     admin: true,
     desc: 'Adds brons to a user.',
 
-    async execute(message, args) {
+    async execute(message, args, client) {
         if (message.guild?.id !== config.guild) {
             setTimeout(() => message.delete().catch(() => { }), 200);
         }
@@ -326,7 +326,7 @@ export const add: MessageCommand = {
         await DB.addBrons(res!.id, amount);
         await message.channel.send({
             content: `${res} ${amount < 0 ? 'lost' : 'gained'} ` +
-                `${Math.abs(amount)} ${message.client.bot_emojis.brons}.`,
+                `${Math.abs(amount)} ${client.bot_emojis.brons}.`,
             allowedMentions: { users: [] }
         }).then(msg => {
             if (message.guild?.id === config.guild) return;
@@ -420,14 +420,14 @@ export const start: MessageCommand = {
     admin: true,
     desc: 'For when bot is ready again.',
 
-    async execute(message) {
+    async execute(message, _args, client) {
         setTimeout(() => message.delete().catch(() => { }), 200);
-        if (message.client.is_listening) {
+        if (client.is_listening) {
             return message.reply({ content: "I'm already listening." })
                 .then(msg => setTimeout(() => msg.delete(), 2000))
                 .catch(() => { });
         }
-        message.client.is_listening = true;
+        client.is_listening = true;
         return message.reply({ content: "I'm listening again." })
             .then(msg => setTimeout(() => msg.delete(), 2000))
             .catch(() => { });
@@ -439,14 +439,14 @@ export const stop: MessageCommand = {
     admin: true,
     desc: 'For when bot needs to be shut down immediately.',
 
-    async execute(message) {
+    async execute(message, _args, client) {
         setTimeout(() => message.delete().catch(() => { }), 200);
-        if (!message.client.is_listening) {
+        if (!client.is_listening) {
             return message.channel.send({ content: 'I already stopped listening.' })
                 .then(msg => setTimeout(() => msg.delete(), 2000))
                 .catch(() => { });
         }
-        message.client.is_listening = false;
+        client.is_listening = false;
         return message.channel.send({ content: 'I stopped listening.' })
             .then(msg => setTimeout(() => msg.delete(), 2000))
             .catch(() => { });

--- a/src/commands/anime_commands.ts
+++ b/src/commands/anime_commands.ts
@@ -2005,8 +2005,7 @@ export const dall: SlashCommand = {
 
         const deleted = await DB.deleteUserCommonCharacters(interaction.user.id, { start, end });
         await DB.addBrons(interaction.user.id, deleted);
-        embed.setDescription(`Succesfully deleted ${deleted} common(s)! ` +
-            `+${deleted} ${client.bot_emojis.brons}`);
+        embed.setDescription(`Succesfully deleted ${deleted} common(s)! +${deleted} ${client.bot_emojis.brons}`);
         return interaction.editReply({ embeds: [embed] });
     }
 };

--- a/src/commands/fun_commands.ts
+++ b/src/commands/fun_commands.ts
@@ -171,7 +171,7 @@ export const getid: SlashCommand = {
                 return u.map(u => ({ name: `@${u.username}`, id: u.id }));
             }, { context: query }
         ).then(results => results.flat()) ?? [];
-        const res = await Utils.get_results(client, interaction, users, {
+        const res = await Utils.get_results(interaction, users, {
             title_fmt: n => `Found ${n} users:`,
             desc_fmt: u => `${u.name}`,
             sel_fmt: u => `**${u.name}**`

--- a/src/commands/music_commands.ts
+++ b/src/commands/music_commands.ts
@@ -318,10 +318,10 @@ const play: SlashSubcommand & PlayPrivates = {
         return true;
     },
 
-    async execute(interaction) {
+    async execute(interaction, client) {
         let guildVoice = GuildVoices.get(interaction.guildId!);
         if (!guildVoice) {
-            await join.execute(interaction);
+            await join.execute(interaction, client);
             guildVoice = GuildVoices.get(interaction.guildId!);
             if (!guildVoice) return;
         } else {
@@ -463,14 +463,14 @@ const host: SlashSubcommand = {
           'Usage: `/music host`\n\n' +
           'Examples: `/music host`',
 
-    async execute(interaction) {
+    async execute(interaction, client) {
         await interaction.deferReply();
         const guildVoice = GuildVoices.get(interaction.guildId!);
         if (!guildVoice) {
             return interaction.editReply({ content: 'I am not in a voice channel.' });
         }
         let host = guildVoice.host.toString() as string;
-        if (guildVoice.host.id === interaction.client.user.id) {
+        if (guildVoice.host.id === client.user!.id) {
             host = 'me';
         } else if (guildVoice.host.id === interaction.user.id) {
             host = 'you';
@@ -938,9 +938,9 @@ const remove: SlashSubcommandGroup = {
     subcommands: new Map()
         .set(remove_song.data.name, remove_song),
 
-    async execute(interaction) {
+    async execute(interaction, client) {
         const subcmd = this.subcommands!.get(interaction.options.getSubcommand());
-        return subcmd!.execute(interaction);
+        return subcmd!.execute(interaction, client);
     }
 };
 
@@ -996,9 +996,9 @@ const vote: SlashSubcommandGroup = {
     subcommands: new Map()
         .set(vote_skip.data.name, vote_skip),
 
-    async execute(interaction) {
+    async execute(interaction, client) {
         const subcmd = this.subcommands!.get(interaction.options.getSubcommand());
-        return subcmd!.execute(interaction);
+        return subcmd!.execute(interaction, client);
     }
 };
 
@@ -1103,26 +1103,26 @@ export const music: SlashCommand = {
 
     desc: 'Music base command',
     
-    async textInput(interaction) {
+    async textInput(interaction, client) {
         const subcommand = this.subcommands!.get(interaction.customId.split('/')[1]);
-        return subcommand!.textInput!(interaction);
+        return subcommand!.textInput!(interaction, client);
     },
 
-    async buttonReact(interaction) {
+    async buttonReact(interaction, client) {
         const subcommand = this.subcommands!.get(interaction.customId.split('/')[2]);
-        return subcommand!.buttonReact!(interaction);
+        return subcommand!.buttonReact!(interaction, client);
     },
 
-    async menuReact(interaction) {
+    async menuReact(interaction, client) {
         const subcommand = this.subcommands!.get(interaction.customId.split('/')[2]);
-        return subcommand!.menuReact!(interaction);
+        return subcommand!.menuReact!(interaction, client);
     },
 
-    async execute(interaction) {
+    async execute(interaction, client) {
         const subcmd = this.subcommands!.get(
             interaction.options.getSubcommand(false) ??
             interaction.options.getSubcommandGroup()!
         );
-        return subcmd!.execute(interaction);
+        return subcmd!.execute(interaction, client);
     }
 };

--- a/src/modules/database.ts
+++ b/src/modules/database.ts
@@ -1177,7 +1177,7 @@ export async function deleteUserCharacter(char: Character) {
     ).then(res => res[0].length);
 }
 export async function deleteUserCommonCharacters(userID: string, { start = 1, end }: Range = {}) {
-    let q = 'DELETE FROM user_chars WHERE uid = $1 AND fc = FALSE AND idx >= $2::bigint';
+    let q = 'DELETE FROM all_user_chars WHERE uid = $1 AND fc = FALSE AND idx >= $2::bigint';
     const params: string[] = [userID, start.toString()];
     if (end) {
         params.push(end.toString());

--- a/src/modules/database.ts
+++ b/src/modules/database.ts
@@ -408,7 +408,7 @@ export function start() {
     return pool.query('DELETE FROM local_data WHERE CURRENT_DATE >= expiry').then(() => false, () => true);
 }
 export function end() {
-    return pool.end();
+    return pool.end().catch(() => { });
 }
 export function getUidsList(shardId: number, totalShards: number) {
     return query<{ uid: string }>(

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -242,7 +242,6 @@ export function timestamp(date: Date | number, fmt: DateFormats = 'f') {
  * returns: T if selected, undefined if no choices, and null if cancelled
  */
 export async function get_results<T>(
-    client: CustomClient,
     interaction: DTypes.RepliableInteraction,
     choices: T[],
     {
@@ -255,6 +254,7 @@ export async function get_results<T>(
         sel_fmt?: (arg: T) => string
     } = {}
 ) {
+    const client = new CustomClient();
     if (choices.length <= 1) return choices[0] as T | undefined;
 
     // Take first 10 results

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -242,6 +242,7 @@ export function timestamp(date: Date | number, fmt: DateFormats = 'f') {
  * returns: T if selected, undefined if no choices, and null if cancelled
  */
 export async function get_results<T>(
+    client: CustomClient,
     interaction: DTypes.RepliableInteraction,
     choices: T[],
     {
@@ -291,6 +292,6 @@ export async function get_results<T>(
             if (i.values[0] === '-1') return null;
             return choices[parseInt(i.values[0])];
         }).catch(() => null);
-    (interaction.client as CustomClient).deleteFollowUp(interaction, message);
+    client.deleteFollowUp(interaction, message);
     return res;
 }


### PR DESCRIPTION
Many, many instances of type casting into CustomClient, as well as some really long "as" statements. This PR attempts to remove as many of those possible. Most of them occur in the command handler, where the CustomClient type isn't in `interaction.client` so instead we simply pass it as an extra argument, since the command handler has the correct instance of CustomClient.

Utils is completely separate from all other command handlers, so they can use `new CustomClient()` invocation, due to the fact that CustomClient is a singleton.