### PR TITLE
Moved delete followup to utils

### DIFF
--- a/src/classes/client.ts
+++ b/src/classes/client.ts
@@ -1,6 +1,6 @@
 import config from '@config';
 import {
-    Client, ContextMenuCommandBuilder, Routes, SlashCommandSubcommandBuilder,
+    Client, ContextMenuCommandBuilder, SlashCommandSubcommandBuilder,
     SlashCommandSubcommandGroupBuilder, SlashCommandBuilder
 } from 'discord.js';
 import type DTypes from 'discord.js';
@@ -110,7 +110,6 @@ export class CustomClient extends Client<true> {
     admin_commands!: Map<string, MessageCommand>;    // All admin commands
     message_commands!: Map<string, MessageCommand>;  // All message commands
     user_cache_ready!: boolean;                      // Whether user cache is ready for current shard
-    deleteFollowUp!: (i: DTypes.RepliableInteraction, msg: DTypes.Message) => Promise<unknown>;
 
     private static _instance: CustomClient;
 
@@ -126,9 +125,6 @@ export class CustomClient extends Client<true> {
         this.lines = [];
         this.commands = new Map();
         this.user_cache_ready = false;
-        this.deleteFollowUp = async (i, msg) => {
-            return this.rest.delete(Routes.webhookMessage(i.webhook.id, i.token, msg.id));
-        };
         // Everything is ready, set instance here
         CustomClient._instance = this;
     }

--- a/src/commands/anime_commands.ts
+++ b/src/commands/anime_commands.ts
@@ -126,7 +126,7 @@ async function wait_for_button(
             }
             return true;
         }).catch(() => false);
-    return client.deleteFollowUp(interaction, message).then(() => res);
+    return Utils.deleteEphemeralMessage(interaction, message).then(() => res);
 }
 
 // Simple function to calculate how many pages there are if there are 10 items per page.
@@ -1338,7 +1338,7 @@ async function switch_char_image(
         if (i.values[0] === '-1') return;
         return parseInt(i.values[0]);
     }).catch(() => { });
-    client.deleteFollowUp(interaction, message).then(() => { }).catch(() => { });
+    Utils.deleteEphemeralMessage(interaction, message).then(() => { }).catch(() => { });
     let success = true;
     if (selected === undefined) {
         return;

--- a/src/commands/fun_commands.ts
+++ b/src/commands/fun_commands.ts
@@ -297,7 +297,7 @@ export const hoyolab: SlashCommand & HoyolabPrivates = {
             if (i.customId === 'hcancel') return;
             return true;
         }).catch(() => undefined);
-        await client.deleteFollowUp(interaction, message);
+        await Utils.deleteEphemeralMessage(interaction, message);
         if (!confirmed) return;
 
         const res = await DB.deleteCookie(interaction.user.id, id);

--- a/src/commands/help_command.ts
+++ b/src/commands/help_command.ts
@@ -70,7 +70,7 @@ async function get_results_category(
             if (i.values[0] === '-1') return null;
             return choices[parseInt(i.values[0])];
         }).catch(() => null);
-    client.deleteFollowUp(interaction, message);
+    Utils.deleteEphemeralMessage(interaction, message);
     return res;
 }
 
@@ -162,7 +162,7 @@ async function get_results_cmd(client: CustomClient, interaction: DTypes.Repliab
             if (i.values[0] === '-1') return null;
             return choices[parseInt(i.values[0])];
         }).catch(() => null);
-    client.deleteFollowUp(interaction, message);
+    Utils.deleteEphemeralMessage(interaction, message);
     return res;
 }
 

--- a/src/commands/mod_commands.ts
+++ b/src/commands/mod_commands.ts
@@ -96,7 +96,7 @@ export const purge: SlashCommand & PurgePrivates = {
             .then(msg => { setTimeout(() => msg.delete(), 3000); }).catch(() => { });
     },
 
-    async execute(interaction, client) {
+    async execute(interaction) {
         const message = await interaction.reply({
             content: 'Performing intensive calculations...',
             ephemeral: true
@@ -220,7 +220,7 @@ export const purge: SlashCommand & PurgePrivates = {
             deleted += await strategy(to_delete);
         }
 
-        await client.deleteFollowUp(interaction, message);
+        await Utils.deleteEphemeralMessage(interaction, message);
         return interaction.channel!.send({ content: `${interaction.user} deleted ${deleted} message(s).` })
             .then(m => setTimeout(() => m.delete(), 3000)).catch(() => { });
     }


### PR DESCRIPTION
Previously, we put deleteFollowUp in client, however that is completely unnecessary with the new Utils, as the client is contained within the interaction itself. Furthermore, the name is a little misleading, as it is able to safely delete ANY ephemeral message from the correct interaction.