### PR TITLE
Migrate Gacha System to new one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "@types/cookie": "^0.5.3",
         "@types/glob": "^8.1.0",
-        "@types/node": "^20.8.9",
+        "@types/node": "^20.8.10",
         "@types/pg": "^8.10.7",
         "@types/pg-copy-streams": "^1.2.4",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
@@ -494,9 +494,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
-      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/cookie": "^0.5.3",
     "@types/glob": "^8.1.0",
-    "@types/node": "^20.8.9",
+    "@types/node": "^20.8.10",
     "@types/pg": "^8.10.7",
     "@types/pg-copy-streams": "^1.2.4",
     "@typescript-eslint/eslint-plugin": "^6.9.1",

--- a/sqls/schema.sql
+++ b/sqls/schema.sql
@@ -132,9 +132,7 @@ CREATE TABLE waifus (
     img text[] not null,
     nimg text[] not null,
     UNIQUE(name, gender, origin),
-    CHECK (array_length(img, 1) > 0),
-    CHECK (array_length(img, 1) < 10),
-    CHECK (array_length(nimg, 1) < 10)
+    CHECK (array_length(img, 1) > 0)
 );
 CREATE INDEX ON waifus (name);
 CREATE INDEX ON waifus (origin);
@@ -177,7 +175,8 @@ CREATE TABLE user_chars (
     CHECK (lvl > 0),
     CHECK (_img > 0),
     CHECK (_nimg > 0),
-    CHECK (idx > 0)
+    CHECK (idx > 0),
+    CHECK (_img <= lvl)
 );
 
 -- Trigger to automatically generate an index for user
@@ -310,8 +309,7 @@ SELECT
 FROM get_user_chars(uuid)
 NATURAL JOIN
 (
-    SELECT wid FROM chars
-    WHERE fc = TRUE AND array_length(img, 1) > 1
+    SELECT wid FROM chars WHERE fc = TRUE
 ) A
 ORDER BY idx
 $$ LANGUAGE SQL;
@@ -322,11 +320,11 @@ CREATE OR REPLACE FUNCTION is_upgradable(wwid bigint)
     RETURNS boolean
 AS $$
 DECLARE
-    img_len int;
+    upgradable boolean;
 BEGIN
-    SELECT array_length(img, 1) INTO STRICT img_len
+    SELECT fc INTO STRICT upgradable
     FROM chars WHERE wid = wwid;
-    RETURN img_len > 1;
+    RETURN upgradable;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/src/commands/anime_commands.ts
+++ b/src/commands/anime_commands.ts
@@ -114,7 +114,6 @@ async function search_character(
 
 // Global helper that waits for a confirm/cancel interaction
 async function wait_for_button(
-    client: CustomClient,
     interaction: DTypes.RepliableInteraction,
     message: DTypes.Message,
     fn: string
@@ -443,7 +442,7 @@ export const anime: SlashCommand = {
         let desc = `__Anime found:__\n*${series}*\n\n**Found ${count} character(s):**\n`;
         for (const [idx, char] of anime_chars.entries()) {
             let obtained = '🟩';
-            let uStatus = char.getUStatus();
+            let uStatus = '';
             let wFC = char.fc ? '⭐ ' : '';
             const user_char = await DB.fetchUserCharacter(user.id, char.wid).catch(() => { });
             if (user_char) {
@@ -1135,28 +1134,20 @@ async function get_char_as_embed(
     // Only enable if user is the author.
     if (authorID === target.id) {
         await character.loadWaifu();
-        if (character.thisIsUpgradable()) {
-            if (character.isUpgradable) {
-                menu.addOptions({
-                    label: 'Upgrade!',
-                    value: `${fn}/${authorID}/upgrade_char/${character.wid}`,
-                    emoji: '⏫'
-                });
-            }
-            const is_nsfw = Utils.channel_is_nsfw_safe(channel) && character.nsfw;
-            if (!is_nsfw && character.isSwitchable) {
-                menu.addOptions({
-                    label: 'Change image!',
-                    value: `${fn}/${authorID}/toggle_char/${character.wid}`,
-                    emoji: '🔄'
-                });
-            } else if (is_nsfw && character.isNSwitchable) {
-                menu.addOptions({
-                    label: 'Change lewd!',
-                    value: `${fn}/${authorID}/toggle_char/${character.wid}`,
-                    emoji: '🔄'
-                });
-            }
+        const is_nsfw = Utils.channel_is_nsfw_safe(channel) && character.nsfw;
+        // Switching image is always available; not all images are always available however.
+        if (!is_nsfw) {
+            menu.addOptions({
+                label: 'Change image!',
+                value: `${fn}/${authorID}/toggle_char/${character.wid}`,
+                emoji: '🔄'
+            });
+        } else if (is_nsfw) {
+            menu.addOptions({
+                label: 'Change lewd!',
+                value: `${fn}/${authorID}/toggle_char/${character.wid}`,
+                emoji: '🔄'
+            });
         }
         if (Utils.channel_is_nsfw_safe(channel) && character.isNToggleable) {
             menu.addOptions({
@@ -1166,9 +1157,9 @@ async function get_char_as_embed(
             });
         }
         menu.addOptions({
-            label: 'Delete this character!',
+            label: 'Sell this character!',
             value: `${fn}/${authorID}/delete_char/${character.wid}`,
-            emoji: '🚮'
+            emoji: '💰'
         });
     }
     // Enable if there are options
@@ -1222,123 +1213,107 @@ async function get_char_as_embed(
 }
 
 type FnMap = {
-    [key: string]: ((
+    [key: string]: (
         client: CustomClient,
         interaction: DTypes.AnySelectMenuInteraction,
         char: DB.Character
     ) => Promise<{
         embeds: DTypes.EmbedBuilder[],
         ephemeral: boolean
-    } | undefined>) | undefined;
+    } | undefined>;
 };
 const fnMappings: FnMap = {
-    'upgrade_char': upgrade,
     'toggle_char': switch_char_image,
     'ntoggle_char': toggle_char_nsfw,
     'delete_char': delete_char
 };
-
-// Upgrades a character and returns a followup component
-async function upgrade(client: CustomClient, interaction: DTypes.AnySelectMenuInteraction, char: DB.Character) {
-    const brons = await DB.getBrons(interaction.user.id);
-    // Match gacha_docs
-    const costs = [0, 100, 500, 1000];
-    const embed = new EmbedBuilder({ color: Colors.Red });
-    if (brons! < costs[char.lvl]) {
-        embed.setTitle(`You don't have enough brons to upgrade ${char.name} ` +
-            `to level ${char.lvl + 1}. Required: ${costs[char.lvl]} ` +
-            `${client.bot_emojis.brons}`);
-        return { embeds: [embed], ephemeral: true };
-    }
-    const buttons = new ActionRowBuilder<ButtonBuilder>()
-        .addComponents(
-            new ButtonBuilder()
-                .setCustomId('upgrade_char/confirm')
-                .setLabel('Yes!')
-                .setEmoji('⏫')
-                .setStyle(ButtonStyle.Success),
-            new ButtonBuilder()
-                .setCustomId('upgrade_char/cancel')
-                .setLabel('No')
-                .setStyle(ButtonStyle.Secondary));
-    embed.setColor(Colors.Gold).setTitle(
-        `Are you sure you want to use ${costs[char.lvl]} ` +
-        `${client.bot_emojis.brons} to upgrade ${char.name} ` +
-        `to level ${char.lvl + 1}?`
-    );
-    const message = await interaction.followUp({
-        embeds: [embed],
-        components: [buttons],
-        ephemeral: true
-    });
-    const confirmed = await wait_for_button(client, interaction, message, 'upgrade_char');
-    if (!confirmed) return;
-
-    const ret = await char.upgrade(costs[char.lvl]);
-    if (ret) {
-        embed.setTitle(`Failed to upgrade ${char.name}. Reason: \`${ret}\``);
-    } else {
-        embed.setTitle(`Successfully upgraded ${char.name} to level ${char.lvl}!`);
-    }
-    return { embeds: [embed], ephemeral: true };
-}
 
 async function switch_char_image(
     client: CustomClient,
     interaction: DTypes.AnySelectMenuInteraction,
     char: DB.Character
 ) {
-    const embed = new EmbedBuilder({ color: Colors.Gold });
-    const menu = new StringSelectMenuBuilder()
-        .setCustomId('toggle_char/menu')
-        .setPlaceholder('Select an image.');
-    // Assuming char is switchable
-    const embeds = [];
     const is_nsfw = Utils.channel_is_nsfw_safe(interaction.channel!) && char.nsfw;
-    await char.loadWaifu();
-    if (is_nsfw) {
-        // Switching lewd image
-        for (const [i, nimg] of char.waifu!.nimg.entries()) {
-            embed.setTitle(`Image #${i + 1}:`)
-                .setDescription(`[Source](${DB.getSource(nimg)})\n[Raw Image](${nimg})`)
-                .setImage(nimg);
-            embeds.push(new EmbedBuilder(embed.data));
-            menu.addOptions({ label: `Image #${i + 1}`, value: (i + 1).toString() });
-        }
-        embed.setTitle(
-            `${char.name} has ${char.waifu!.nimg.length} lewd images.\n` +
-            'Select one to continue or click cancel.'
-        ).setImage(null).setDescription(null);
-        embeds.push(embed);
-    } else {
-        // Otherwise switching normal image
-        for (const [i, img] of char.waifu!.img.entries()) {
-            embed.setTitle(`Image #${i + 1}:`)
+    async function get_char_images_embed(start: number): Promise<DTypes.InteractionReplyOptions> {
+        const embed = new EmbedBuilder({ color: Colors.Gold });
+        const buttons = [];
+        // Assuming char is switchable
+        const embeds = [];
+        await char.loadWaifu();
+        // char.lvl - 4 gives user access to 1 image at level 5.
+        const accessibleImages = is_nsfw ? char.waifu!.nimg.slice(0, char.lvl - 4) : char.waifu!.img.slice(0, char.lvl);
+        const image_page = accessibleImages.slice(start, start + 10);
+        for (const [i, img] of image_page.entries()) {
+            embed.setTitle(`Image #${start + i + 1}:`)
                 .setDescription(`[Source](${DB.getSource(img)})\n[Raw Image](${img})`)
                 .setImage(img);
             embeds.push(new EmbedBuilder(embed.data));
-            menu.addOptions({ label: `Image #${i + 1}`, value: (i + 1).toString() });
+            buttons.push(new ButtonBuilder({
+                label: `Image #${start + i + 1}`,
+                style: ButtonStyle.Primary,
+                customId: `select_char/${start + i + 1}`
+            }));
         }
-        embed.setTitle(
-            `${char.name} has ${char.waifu!.img.length} images.\n` +
-            'Select one to continue or click cancel.'
-        ).setImage(null).setDescription(null);
-        embeds.push(embed);
+
+        // Buttons for navigating over 10 images
+        const toggle_buttons = [
+            new ButtonBuilder()
+                .setEmoji('⬅️')
+                .setStyle(ButtonStyle.Primary)
+                .setCustomId(`toggle_char/${start - 10}`)
+                .setDisabled(start === 0),
+            new ButtonBuilder()
+                .setEmoji('➡️')
+                .setStyle(ButtonStyle.Primary)
+                .setCustomId(`toggle_char/${start + 10}`)
+                .setDisabled(start + 10 >= accessibleImages.length),
+            new ButtonBuilder()
+                .setLabel('Cancel')
+                .setStyle(ButtonStyle.Danger)
+                .setCustomId('select_char/cancel')
+        ];
+        const components = [new ActionRowBuilder<DTypes.ButtonBuilder>().addComponents(toggle_buttons)];
+        while (buttons.length > 0) {
+            components.push(new ActionRowBuilder<DTypes.ButtonBuilder>().addComponents(buttons.splice(0, 5)));
+        }
+        return {
+            embeds,
+            components,
+            ephemeral: true
+        };
     }
-    menu.addOptions({ label: 'Cancel', value: '-1' });
-    const message = await interaction.followUp({
-        embeds: embeds,
-        components: [new ActionRowBuilder<DTypes.StringSelectMenuBuilder>().addComponents(menu)],
-        ephemeral: true
-    });
+    const opts = await get_char_images_embed(0);
+    const message = await interaction.followUp(opts);
+
+    // Recursively create ourselves to handle pagination
+    const createCollector = () => {
+        const collector = message.createMessageComponentCollector({
+            componentType: ComponentType.Button,
+            filter: i => i.customId.startsWith('toggle_char'),
+            max: 1,
+            time: 15 * 60 * 1000 // 15 minutes before interaction expires
+        });
+        collector.once('collect', async i => {
+            await i.deferUpdate();
+            const page = parseInt(i.customId.split('/')[1]);
+            const opts = await get_char_images_embed(page);
+            await i.editReply(opts);
+        });
+        collector.once('end', createCollector);
+    };
+    createCollector();
+
     const selected = await message.awaitMessageComponent({
-        componentType: ComponentType.StringSelect,
-        time: 60_000
+        componentType: ComponentType.Button,
+        filter: i => i.customId.startsWith('select_char'),
+        time: 15 * 60 * 1000 // 15 minutes before interaction expires
     }).then(i => {
-        if (i.values[0] === '-1') return;
-        return parseInt(i.values[0]);
-    }).catch(() => { });
-    Utils.deleteEphemeralMessage(interaction, message).then(() => { }).catch(() => { });
+        const val = i.customId.split('/')[1];
+        if (val === 'cancel') return;
+        return parseInt(val);
+    }).catch(() => undefined);
+    Utils.deleteEphemeralMessage(interaction, message).catch(() => { });
+
     let success = true;
     if (selected === undefined) {
         return;
@@ -1348,7 +1323,10 @@ async function switch_char_image(
         success = await char.setImg(selected);
     }
     if (!success) {
-        embed.setColor(Colors.Red).setTitle('Apologies, that action failed. Please contact the support server.');
+        const embed = new EmbedBuilder({
+            title: 'Apologies, that action failed. Please contact the support server.',
+            color: Colors.Red
+        });
         return { embeds: [embed], ephemeral: true };
     }
 }
@@ -1370,6 +1348,7 @@ async function toggle_char_nsfw(
     }
 }
 
+// TODO: Rewrite
 async function delete_char(client: CustomClient, interaction: DTypes.AnySelectMenuInteraction, char: DB.Character) {
     await char.loadWaifu();
     const embed = new EmbedBuilder({
@@ -1397,7 +1376,7 @@ async function delete_char(client: CustomClient, interaction: DTypes.AnySelectMe
         components: [buttons],
         ephemeral: true
     });
-    const confirmed = await wait_for_button(client, interaction, message, 'delete_char');
+    const confirmed = await wait_for_button(interaction, message, 'delete_char');
     if (!confirmed) return;
     embed.setDescription(null);
 
@@ -1731,29 +1710,20 @@ async function generateCharacterDisplay(
     const img = character.getImage(channel);
     let refund = 0;
     let add_on = '';
-    let add_emoji = '';
+    let add_emoji = ' 🆕';
     if (!character.new) {
         // CONSTANT: Refund brons
-        refund = character.fc ? 4 : 2;
+        refund = character.fc ? 2 : 1;
         const refund_str = `+${refund} ${client.bot_emojis.brons}`;
+        add_emoji = ` 🆒 ${refund_str}`;
         if (character.lvl > 1) {
             add_emoji = ` 🆙 ${refund_str}`;
             add_on = `**Reached level ${character.lvl}!**\n`;
-            if (character.unlockedImages) {
-                add_on += 'You unlocked new image(s)! 🎉\n';
-                add_on += 'Find the waifu to switch the image!\n';
-            } else if (character.unlockedNMode && character.thisIsNToggleable()) {
+            if (character.unlockedNMode) {
                 add_on += 'You unlocked a new mode! 🎉\n';
                 add_on += 'Find the waifu to switch to lewd mode!\n';
-            } else if (character.unlockedNImages && character.thisIsNSwitchable()) {
-                add_on += 'You unlocked new lewd image(s)! 🎉\n';
-                add_on += 'Find the waifu to switch the image!\n';
             }
-        } else {
-            add_emoji = ` 🆒 ${refund_str}`;
         }
-    } else {
-        add_emoji = ' 🆕';
     }
     const embed = new EmbedBuilder({
         description:
@@ -1997,7 +1967,7 @@ export const dall: SlashCommand = {
             embeds: [embed],
             components: [buttons]
         });
-        const confirmed = await wait_for_button(client, interaction, message, 'dall');
+        const confirmed = await wait_for_button(interaction, message, 'dall');
         if (!confirmed) return;
 
         const deleted = await DB.deleteUserCommonCharacters(interaction.user.id, { start, end });
@@ -2302,58 +2272,6 @@ export const users: SlashCommand = {
         return interaction.editReply({ embeds: [embed] });
     }
 };
-
-// Commenting out because unsure if still needed.
-// export const uplist: SlashCommand = {
-//     data: new SlashCommandBuilder()
-//         .setName('uplist')
-//         .addIntegerOption(option =>
-//             option
-//                 .setName('page')
-//                 .setDescription('The page to jump to. (Default: 1)')
-//                 .setMinValue(1))
-//         .setDescription('View all upgradable waifus.'),
-
-//     desc: "Don't know what characters you can upgrade? Check using this command!\n" +
-//           'To switch the image, the character must be at least level 5.\n\n' +
-//           'Usage: `/uplist page: [page] user: [user]`\n\n' +
-//           '__**Options**__\n' +
-//           '*page:* The page number to jump to. (Default 1)\n' +
-//           "*user:* The user's list to compare to. (Default: You)\n\n" +
-//           'Examples: `/uplist`, `/uplist page: 2`',
-
-//     async execute(interaction) {
-
-//     }
-// };
-
-// export const nlist: SlashCommand = {
-//     data: new SlashCommandBuilder()
-//         .setName('nlist')
-//         .addIntegerOption(option =>
-//             option
-//                 .setName('page')
-//                 .setDescription('The page to jump to. (Default: 1)')
-//                 .setMinValue(1))
-//         .addUserOption(option =>
-//             option
-//                 .setName('user')
-//                 .setDescription('The user you want to view. (Default: You)'))
-//         .setDescription('View all lewdable waifus.'),
-
-//     desc: "Don't know what characters you can change into lewd mode? Check using this command!\n\n" +
-//           'To toggle to lewd mode, the character must be in this list and level 8 or higher.\n\n' +
-//           'While in lewd mode, you can change the image (provided there exists more images).\n\n' +
-//           'Usage: `/nlist page: [page] user: [user]`\n\n' +
-//           '__**Options**__\n' +
-//           '*page:* The page number to jump to. (Default: 1)\n' +
-//           "*user:* The user's list to compare to. (Default: You)\n\n" +
-//           'Examples: `/nlist`, `/nlist page: 2`, `/nlist user: @Krammy`',
-
-//     async execute(interaction) {
-
-//     },
-// };
 
 export const swap: SlashCommand = {
     data: new SlashCommandBuilder()
@@ -3088,7 +3006,7 @@ export const submit: CachedSlashCommand<{
         let id = 0;
         message.createMessageComponentCollector({
             componentType: ComponentType.Button,
-            time: 60 * 60 * 1_000 // Cleanup after 1 hr if ignored
+            time: 15 * 60 * 1_000 // Cleanup after 15 mins bc expired
         }).on('collect', async i => {
             // Selected, we can submit.
             if (i.customId === 'selectWaifu') {
@@ -3114,7 +3032,7 @@ export const submit: CachedSlashCommand<{
                 await i.showModal(modal);
                 const res = await i.awaitModalSubmit({
                     filter: s => s.customId === modal.data.custom_id,
-                    time: 10 * 60 * 1_000 // Wait for 10 mins max
+                    time: 15 * 60 * 1_000 // Wait for 15 mins max
                 }).catch(() => { });
                 if (!res) return i.deleteReply(); // Timed out, took too long
                 // Waifu submit search
@@ -3151,7 +3069,7 @@ export const submit: CachedSlashCommand<{
                 await i.showModal(modal);
                 const res = await i.awaitModalSubmit({
                     filter: s => s.customId === modal.data.custom_id,
-                    time: 10 * 60 * 1_000 // Wait for 10 mins max
+                    time: 15 * 60 * 1_000 // Wait for 15 mins max
                 }).catch(() => { });
                 if (!res) return i.deleteReply(); // Timed out, took too long
                 // Anime submit search

--- a/src/commands/anime_commands.ts
+++ b/src/commands/anime_commands.ts
@@ -1242,8 +1242,9 @@ async function switch_char_image(
         // Assuming char is switchable
         const embeds = [];
         await char.loadWaifu();
-        // char.lvl - 4 gives user access to 1 image at level 5.
-        const accessibleImages = is_nsfw ? char.waifu!.nimg.slice(0, char.lvl - 4) : char.waifu!.img.slice(0, char.lvl);
+        const accessibleImages = is_nsfw ?
+            char.waifu!.nimg.slice(0, char.max_nimg) :
+            char.waifu!.img.slice(0, char.max_img);
         const image_page = accessibleImages.slice(start, start + 10);
         for (const [i, img] of image_page.entries()) {
             embed.setTitle(`Image #${start + i + 1}:`)
@@ -1717,8 +1718,8 @@ async function generateCharacterDisplay(
         if (character.lvl > 1) {
             add_emoji = ` 🆙 ${refund_str}`;
             add_on = `**Reached level ${character.lvl}!**\n`;
-            // New img
-            if (character.lvl <= character.waifu!.img.length) {
+            // Unlocked new img
+            if (character.max_img <= character.waifu!.img.length) {
                 add_on += 'You unlocked a new image! 🎉\n';
                 add_on += 'Find the waifu to switch the image!\n';
             }
@@ -1726,7 +1727,8 @@ async function generateCharacterDisplay(
             if (character.unlockedNMode) {
                 add_on += 'You unlocked a new mode! 🎉\n';
                 add_on += 'Find the waifu to switch to lewd mode!\n';
-            } else if (character.lvl - 4 <= character.waifu!.nimg.length) {
+            // Unlocked new nimg
+            } else if (character.max_nimg <= character.waifu!.nimg.length) {
                 add_on += 'You unlocked a new lewd image! 🎉\n';
                 add_on += 'Use lewd mode on the waifu to switch the image!\n';
             }
@@ -2514,17 +2516,13 @@ export const submit: CachedSlashCommand<SubmissionCache> & SubmitPrivates = {
 
     desc: 'Want to add a character that is not currently in the starred database?\n' +
           'You came to the right command!\n' +
-          'If you wish to add images to an existing character,\n' +
-          'make sure to copy the correct name, gender, and anime name.\n' +
-          'Furthermore, it must follow these rules:\n\n' +
+          'Simply just follow these rules:\n\n' +
           '__**Character Submission Rules:**__\n' +
           '1. The character must have an **anime name**. If it has no anime, it goes under "Originals"\n' +
-          '2. If the character is from an **anime** that already exists, it must use the exact same name.\n' +
+          '2. If the character is from an **anime** that already exists, use the anime searcher.\n' +
           "3. The character's **gender** must be one of: `Male`, `Female`, `Unknown`.\n" +
           '4. If its a new character, the character must have at least **one normal image**.\n' +
-          '5. If its a new character, and you include a lewd image, the character must have at least ' +
-          '**two normal images**.\n' +
-          '6. Optionally, if you would like, you can add a file to the `image` option or `lewd` option (up to 9).\n' +
+          '5. Optionally, if you would like, you can add a file to the `image` option or `lewd` option (up to 9).\n' +
           'These links will then be prepopulated in the modal. **DO NOT CHANGE THESE.**\n\n' +
           'Note that you can only submit one file per option at time. This is a discord limitation.\n\n' +
           'Usage: `/submit image(1-9): [file] lewd(1-9): [file]`\n\n' +

--- a/src/commands/anime_commands.ts
+++ b/src/commands/anime_commands.ts
@@ -1104,7 +1104,7 @@ async function get_char_as_embed(
                 return DB.fetchUserHighCharactersList(target.id, idx).then(c => c[0]);
             return DB.fetchUserCharactersList(target.id, idx).then(c => c[0]);
         }
-        let char: DB.Character | null = null;
+        let char: DB.Character | undefined;
         if (high) {
             char = await DB.fetchUserHighCharacter(target.id, wid!);
         } else {
@@ -1477,7 +1477,7 @@ const listHelpers = {
             await DB.fetchUserCharacter(interaction.user.id, wid);
         const callFn = fnMappings[fn];
         if (callFn) {
-            const res = await callFn(client, interaction, char);
+            const res = await callFn(client, interaction, char!);
             if (res) {
                 await interaction.followUp(res);
             }
@@ -1492,7 +1492,7 @@ const listHelpers = {
         if (fn === 'delete_char') {
             res = get_char_as_embed(
                 interaction.channel!, interaction.user.id,
-                interaction.user, char.idx!, high
+                interaction.user, char!.idx!, high
             );
         } else {
             res = get_char_as_embed(

--- a/src/commands/fun_commands.ts
+++ b/src/commands/fun_commands.ts
@@ -292,7 +292,7 @@ export const hoyolab: SlashCommand & HoyolabPrivates = {
 
         const confirmed = await message.awaitMessageComponent({
             componentType: ComponentType.Button,
-            time: 60_000
+            time: 15 * 60 * 1000 // 15 mins before interaction expires
         }).then(async i => {
             if (i.customId === 'hcancel') return;
             return true;

--- a/src/modules/database.ts
+++ b/src/modules/database.ts
@@ -88,23 +88,12 @@ class Waifu {
         return ' ' + this.gender;
     }
 
-    thisIsUpgradable() {
-        return this.img.length > 1;
-    }
-
     thisIsNToggleable() {
         return this.nimg.length !== 0;
     }
 
     thisIsNSwitchable() {
         return this.nimg.length > 1;
-    }
-
-    getUStatus(l = '', r = '') {
-        if (this.thisIsUpgradable()) {
-            return `${l}⏫${r}`;
-        }
-        return '';
     }
 }
 
@@ -181,32 +170,21 @@ class Character {
         this.img = transformImage(row.img);
         this.nimg = transformImage(row.nimg);
         this.nsfw = row.nsfw;
+        // Can be used to do more fun stuff with levels
         this.displayLvl = this.lvl < 0 ? '∞' : this.lvl.toString();
     }
 
-    get unlockedImages() { return this.lvl === 5; }
-    get unlockedNMode() { return this.lvl === 8; }
-    get unlockedNImages() { return this.lvl === 10; }
     /**
      * Only available if {@link loadWaifu} is called.
      * @throws {Error} If waifu is not loaded
      */
-    get isUpgradable() { return 0 < this.lvl && this.lvl <= 4 && this.thisIsUpgradable(); }
+    get unlockedNMode() { return this.lvl === 5 && this.thisIsNToggleable(); }
+
     /**
      * Only available if {@link loadWaifu} is called.
      * @throws {Error} If waifu is not loaded
      */
-    get isSwitchable() { return (this.lvl === -1 || this.lvl >= 5) && this.thisIsUpgradable(); }
-    /**
-     * Only available if {@link loadWaifu} is called.
-     * @throws {Error} If waifu is not loaded
-     */
-    get isNToggleable() { return (this.lvl === -1 || this.lvl >= 8) && this.thisIsNToggleable(); }
-    /**
-     * Only available if {@link loadWaifu} is called.
-     * @throws {Error} If waifu is not loaded
-     */
-    get isNSwitchable() { return (this.lvl === -1 || this.lvl >= 10) && this.thisIsNSwitchable(); }
+    get isNToggleable() { return this.lvl >= 5 && this.thisIsNToggleable(); }
 
     async setImg(new_img: number) {
         const { _img, img } = await setUserCharacterImage(this.uid, this.wid, new_img);
@@ -230,13 +208,6 @@ class Character {
         return retval[0] === undefined;
     }
 
-    async upgrade(cost: number) {
-        const retval = await addUserCharacterLevel(this.uid, this.wid, cost);
-        if (retval) return retval;
-        this.lvl += 1;
-        this.displayLvl = this.lvl.toString();
-    }
-
     async loadWaifu() {
         this.waifu = await this.getWaifu();
         this.loaded = true;
@@ -246,16 +217,8 @@ class Character {
      * Only available if {@link loadWaifu} is called.
      * @throws {Error} If waifu is not loaded
      */
-    thisIsUpgradable() {
-        if (!this.fc) return false;
-        return this.waifu!.thisIsUpgradable();
-    }
-
-    /**
-     * Only available if {@link loadWaifu} is called.
-     * @throws {Error} If waifu is not loaded
-     */
     thisIsNToggleable() {
+        if (!this.loaded) throw new Error('Getting thisIsNToggleable before waifu is loaded');
         if (!this.fc) return false;
         return this.waifu!.thisIsNToggleable();
     }
@@ -265,6 +228,7 @@ class Character {
      * @throws {Error} If waifu is not loaded
      */
     thisIsNSwitchable() {
+        if (!this.loaded) throw new Error('Getting thisIsNSwitchable before waifu is loaded');
         if (!this.fc) return false;
         return this.waifu!.thisIsNSwitchable();
     }
@@ -288,22 +252,18 @@ class Character {
      * @throws {Error} If waifu is not loaded
      */
     getUStatus(l = '', r = '') {
-        if (!this.loaded) throw new Error('Getting ustatus before waifu is loaded');
+        if (!this.loaded) throw new Error('Getting uStatus before waifu is loaded');
+        if (!this.fc) return '';
         // Character doesn't have a level, default waifus database.
-        const lvl = (this.lvl === -1) ? Infinity : (this.lvl ? this.lvl : 1);
-        if (this.thisIsUpgradable()) {
-            if (lvl < 4) {
-                return `${l}⏫${r}`;
-            } else if (lvl === 4) {
-                return `${l}⏏️${r}`;
-            } else if (this.thisIsNSwitchable() && (lvl >= 10)) {
+        const lvl = this.lvl ? this.lvl : 1;
+        if (lvl >= 5) {
+            if (this.thisIsNSwitchable()) {
                 return `${l}🔥${r}`;
-            } else if (this.thisIsNToggleable() && (lvl >= 8)) {
-                return `${l}✨${r}`;
+            } else if (this.thisIsNToggleable()) {
+                return `${l}👑${r}`;
             }
-            return `${l}👑${r}`;
         }
-        return '';
+        return `${l}✨${r}`;
     }
 
     /**
@@ -347,14 +307,11 @@ const pool = new Pool({
 const defaultLimit = 10;
 // Chances to get specific rarities:
 // Can be changed to a sequence to increase chances.
-const special = [50];
-// Once user passes this value, brons cost changes
-const EXTRA_COST_CNT = 60_000;
+const specialRate = [50];
 // Can change brons cost here
-export function getCostPerPull(cnt: number, special: boolean) {
+export function getCostPerPull(special: boolean) {
     // Special = whale, else multi/roll
-    if (special) return 20;
-    else if (cnt >= EXTRA_COST_CNT) return 3;
+    if (special) return 10;
     else return 2;
 }
 
@@ -1010,7 +967,7 @@ function getCommonQuery() {
 function getStarredQuery() {
     return 'SELECT wid FROM chars WHERE fc = TRUE ORDER BY RANDOM() LIMIT 1';
 }
-function getUpgradableStarredQuery() {
+function getMultiStarredQuery() {
     return `SELECT wid FROM chars
         WHERE fc = TRUE AND array_length(img, 1) > 1
         ORDER BY RANDOM() LIMIT 1`;
@@ -1018,25 +975,25 @@ function getUpgradableStarredQuery() {
 const enum GuaranteeLevel {
     COMMON = 0,
     STARRED,
-    UPGRADABLE
+    MULTI_STARS
 }
 function generateCharacterQuery(level: GuaranteeLevel) {
     const random = Math.floor(Math.random() * 101);
     switch (level) {
         case GuaranteeLevel.COMMON:
-            if (special.includes(random)) {
+            if (specialRate.includes(random)) {
                 return getStarredQuery();
             } else {
                 return getCommonQuery();
             }
         case GuaranteeLevel.STARRED:
-            if (special.includes(random)) {
-                return getUpgradableStarredQuery();
+            if (specialRate.includes(random)) {
+                return getMultiStarredQuery();
             } else {
                 return getStarredQuery();
             }
-        case GuaranteeLevel.UPGRADABLE:
-            return getUpgradableStarredQuery();
+        case GuaranteeLevel.MULTI_STARS:
+            return getMultiStarredQuery();
     }
 }
 // Special type of character that also includes whether it is new or old
@@ -1044,8 +1001,7 @@ export type CharacterInsert = Character & { new: boolean };
 // Used for single pulls
 export async function generateAndAddCharacter(userID: string, amtTaken: { amt: number }):
     Promise<CharacterInsert | string> {
-    const cnt = await fetchUserCharacterCount(userID);
-    const amt = getCostPerPull(cnt, false);
+    const amt = getCostPerPull(false);
     amtTaken.amt = -amt; // Returning to the front end brons difference
     return multi_query<CharacterDetails & { new: boolean }>(
         [
@@ -1067,13 +1023,12 @@ export async function generateAndAddCharacter(userID: string, amtTaken: { amt: n
         return 'there was an error with the database.';
     });
 }
-export async function generateAndAddCharacters(userID: string, special: boolean, amtTaken: { amt: number }):
+export function generateAndAddCharacters(userID: string, special: boolean, amtTaken: { amt: number }):
     Promise<CharacterInsert[] | string> {
     // special = false - multi
     // special = true - whales
     const PULL_AMT = 10;
-    const cnt = await fetchUserCharacterCount(userID);
-    const amt = getCostPerPull(cnt, special) * PULL_AMT;
+    const amt = getCostPerPull(special) * PULL_AMT;
     amtTaken.amt = -amt; // Returning to the front end brons difference
     const queries = ['CALL sub_brons($1, $2, $3)'];
     const params: string[][] = [[userID, special.toString(), amt.toString()]];
@@ -1094,7 +1049,7 @@ export async function generateAndAddCharacters(userID: string, special: boolean,
         }
     }
     // Finally, add the guaranteed character.
-    qstring = generateCharacterQuery(special ? GuaranteeLevel.UPGRADABLE : GuaranteeLevel.STARRED);
+    qstring = generateCharacterQuery(special ? GuaranteeLevel.MULTI_STARS : GuaranteeLevel.STARRED);
     queries.push(`SELECT * FROM add_character($1, (${qstring}))`);
     params.push([userID]);
     return multi_query<CharacterDetails & { new: boolean }>(
@@ -1111,23 +1066,6 @@ export async function generateAndAddCharacters(userID: string, special: boolean,
         if (err instanceof DatabaseMaintenanceError) throw err;
         else if (err.message.includes('user_info_brons_check')) return 'not enough brons';
         else if (err.message.includes('whale_fail_error')) return 'you already whaled today';
-        else if (err.message.includes('user_not_found_error')) return 'you do not have an existing account';
-        // This means that nothing happened (ACID).
-        return 'there was an error with the database.';
-    });
-}
-function addUserCharacterLevel(userID: string, wid: string, amt: number) {
-    return multi_query(
-        [
-            'CALL sub_brons($1, FALSE, $2)',
-            `UPDATE user_chars SET lvl = lvl + 1
-                WHERE uid = $1 AND wid = $2
-            RETURNING *`
-        ],
-        [[userID, amt], [userID, wid]]
-    ).then(() => { }).catch((err: Error) => {
-        if (err instanceof DatabaseMaintenanceError) throw err;
-        else if (err.message.includes('user_info_brons_check')) return 'not enough brons';
         else if (err.message.includes('user_not_found_error')) return 'you do not have an existing account';
         // This means that nothing happened (ACID).
         return 'there was an error with the database.';

--- a/src/modules/database.ts
+++ b/src/modules/database.ts
@@ -969,7 +969,7 @@ function getStarredQuery() {
 }
 function getMultiStarredQuery() {
     return `SELECT wid FROM chars
-        WHERE fc = TRUE AND array_length(img, 1) > 1
+        WHERE fc = TRUE AND array_length(img, 1) > 1 OR array_length(nimg, 1) > 0
         ORDER BY RANDOM() LIMIT 1`;
 }
 const enum GuaranteeLevel {

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -299,11 +299,13 @@ export async function get_results<T>(
     });
 
     // Return promise to let caller await it.
-    const res = await message.awaitMessageComponent({ componentType: ComponentType.StringSelect, time: 60_000 })
-        .then(i => {
-            if (i.values[0] === '-1') return null;
-            return choices[parseInt(i.values[0])];
-        }).catch(() => null);
+    const res = await message.awaitMessageComponent({
+        componentType: ComponentType.StringSelect,
+        time: 15 * 60 * 1000 // 15 minutes before interaction token expires.
+    }).then(i => {
+        if (i.values[0] === '-1') return null;
+        return choices[parseInt(i.values[0])];
+    }).catch(() => null);
     return deleteEphemeralMessage(interaction, message).then(() => res);
 }
 


### PR DESCRIPTION
- [x] Whales will now cost 10 per pull, (total of 100 brons)
- [x] All starred will become upgradable
  - As a result, how you unlock images have changed too
- [x] Now your level gives you how many images you unlock, nimg starts at 5.
  - For example, if you are level 5, you unlock 5 normal images, and 1 nimg. Hitting level 6 will grant you 6 normal images and 2 nimgs.
  - Bonus of this change: All characters will now have unlimited (kind of, not too wild, please) images available to be added (previously 9)

To be implemented in a different PR:
- [ ] ~~Brand new selling system to sell levels~~
  - ~~at the cost of no more manually buying character levels (upgrading)~~
  - ~~current idea is to sell for 5-10 brons per level~~
- [x] Common dupe will now refund 1 bron instead of 2 and star dupe will now refund 2 brons instead of 4
  - However, at the same time, no increased cost of multi when you hit over 60,000 characters