### PR TITLE
Fix illustration bug and update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   "devDependencies": {
     "@types/cookie": "^0.6.0",
     "@types/glob": "^8.1.0",
-    "@types/node": "^20.10.6",
+    "@types/node": "^20.11.5",
     "@types/pg": "^8.10.9",
     "@types/pg-copy-streams": "^1.2.5",
-    "@typescript-eslint/eslint-plugin": "^6.17.0",
-    "@typescript-eslint/parser": "^6.17.0",
+    "@typescript-eslint/eslint-plugin": "^6.19.0",
+    "@typescript-eslint/parser": "^6.19.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
     "tsc-alias": "^1.8.8",
@@ -54,15 +54,15 @@
   "dependencies": {
     "@discordjs/voice": "^0.16.1",
     "cheerio": "^1.0.0-rc.12",
-    "chrono-node": "^2.7.4",
+    "chrono-node": "^2.7.5",
     "cookie": "^0.6.0",
     "discord.js": "^14.14.1",
-    "dotenv": "^16.3.1",
+    "dotenv": "^16.3.2",
     "env-cmd": "^10.1.0",
     "pg": "^8.11.3",
     "pg-copy-streams": "^6.0.6",
     "pixiv.ts": "github:KrammyGod/pixiv.ts",
     "play-dl": "^1.9.7",
-    "sodium-native": "^4.0.4"
+    "sodium-native": "^4.0.5"
   }
 }

--- a/src/modules/scraper.ts
+++ b/src/modules/scraper.ts
@@ -24,7 +24,7 @@ export default async function scrape(source: string) {
         // We attempt to extract the image # from the url
         // Image number is always after /artworks/id, and at the end
         // @ts-expect-error parseInt can handle undefined
-        let imageNumber = parseInt(source.match(/\/artworks\/\d{8,}\/(?<id>-?[0-9]+)$/)?.groups.id);
+        let imageNumber = parseInt(source.match(/\/artworks\/\d{7,}\/(?<id>-?[0-9]+)$/)?.groups.id);
         if (imageNumber > 0) --imageNumber; // Positive indexes start at 0
 
         const res = await pixiv.illust.get(source).catch(() => {


### PR DESCRIPTION
Illustrations in pixiv can be 7 in length instead of 8. Quick bugfix and package update.