### PR TITLE
fix: disable music commands

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,4 +4,5 @@ export * as fun from './fun_commands';
 export * as help from './help_command';
 export * as minigame from './minigame_commands';
 export * as mod from './mod_commands';
-export * as music from './music_commands';
+// Disabling all music commands atm, there is currently an issue with the player interacting with youtube's API
+// export * as music from './music_commands';


### PR DESCRIPTION
ATM, play-dl's interaction with the youtube API doesn't work as it changed to disallow scrapers. Will be looking into fixing this myself, or waiting on a fix/switching packages. For now, since it is broken, temporarily disable the music features.