### PR TITLE
refactor: add type safety to command file exports

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,8 +1,9 @@
-export * as admin from './admin_commands';
-export * as anime from './anime_commands';
-export * as fun from './fun_commands';
-export * as help from './help_command';
-export * as minigame from './minigame_commands';
-export * as mod from './mod_commands';
+import type { CommandFile } from '@classes/commands';
+export const admin = import('./admin_commands') as unknown as CommandFile;
+export const anime = import('./anime_commands') as unknown as CommandFile;
+export const fun = import('./fun_commands') as unknown as CommandFile;
+export const help = import('./help_command') as unknown as CommandFile;
+export const minigame = import('./minigame_commands') as unknown as CommandFile;
+export const mod = import('./mod_commands') as unknown as CommandFile;
 // Disabling all music commands atm, there is currently an issue with the player interacting with youtube's API
-// export * as music from './music_commands';
+// export const music = import('./music_commands') as unknown as CommandFile;

--- a/src/deployment/deploy_commands.ts
+++ b/src/deployment/deploy_commands.ts
@@ -33,6 +33,12 @@ function isString(isThisString: unknown): isThisString is string {
     return typeof isThisString === 'string';
 }
 
+// This function helps us assert that the values of importing all the commands
+// is of type CommandFile. This is useful for type checking.
+function valuesOfCommandFiles(commands: Record<string, CommandFile>): CommandFile[] {
+    return Object.values(commands);
+}
+
 type JSONConvertible = SharedNameAndDescription & { toJSON(): RESTPostAPIChatInputApplicationCommandsJSONBody };
 
 (async function () {
@@ -42,8 +48,8 @@ type JSONConvertible = SharedNameAndDescription & { toJSON(): RESTPostAPIChatInp
     )[] = [];
     const rest = new REST({ version: '10' }).setToken(token);
 
-    for (const commandFile of Object.values(commands)) {
-        Object.values(commandFile as unknown as CommandFile).forEach(command => {
+    for (const commandFile of valuesOfCommandFiles(commands)) {
+        Object.values(commandFile).forEach(command => {
             // Ignore name and desc exported properties.
             if (isString(command)) return;
             // Do not deploy message commands.

--- a/src/modules/load_commands.ts
+++ b/src/modules/load_commands.ts
@@ -6,13 +6,19 @@ function isString(isThisString: unknown): isThisString is string {
     return typeof isThisString === 'string';
 }
 
+// This function helps us assert that the values of importing all the commands
+// is of type CommandFile. This is useful for type checking.
+function valuesOfCommandFiles(commands: Record<string, CommandFile>): CommandFile[] {
+    return Object.values(commands);
+}
+
 export default function load(client: Client) {
     // Reset to prevent duplicate loads
     client.cogs = [];
     client.interaction_commands = new Map();
     client.message_commands = new Map();
 
-    for (const commandFile of Object.values(commands)) {
+    for (const commandFile of valuesOfCommandFiles(commands)) {
         // Initialize a cog object
         const cog: Cog = {
             name: commandFile.name,
@@ -20,8 +26,8 @@ export default function load(client: Client) {
             displayed_commands: [],
             real_command_count: 0,
         };
-        // We assert that commandFile is a CommandFile object. If we don't follow it, it's the developer's fault.
-        Object.values(commandFile as unknown as CommandFile).forEach(command => {
+        // We assert that commandFile is a CommandFile object. If we error here, it's the developer's fault.
+        Object.values(commandFile).forEach(command => {
             // Ignore name and desc exported properties.
             if (isString(command)) return;
             if (command.isSlashCommand() || (command.isMessageCommand() && !command.admin)) {


### PR DESCRIPTION
This simple change lets us assert in the places where we load/deploy commands that the imported file is of command type, and not some other type we didn't expect.