### PR TITLE
fix(music): use the distro ffmpeg in the container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ kubectl kustomize kustomize/overlays/pr
 
 - **`kustomize/overlays/*/{bot,database}/sealed-secret.yaml` contain real committed ciphertext.** Never overwrite them with placeholders to make a render succeed, and never delete them. SealedSecret ciphertext is bound to its namespace *and* name, so it cannot be regenerated from this repo.
 - **`NPM_VERSION` in the Dockerfile must match the npm that generated `package-lock.json`.** A mismatch makes `npm ci` fail on lockfile contents that are actually fine.
-- **`FFMPEG_BIN` must keep pointing the container at the distro ffmpeg.** `ffmpeg-static`'s binary is statically linked against a much older glibc, and static glibc cannot resolve hostnames without matching NSS modules to dlopen, so in-cluster it fails every lookup with "Failed to resolve hostname: System error". Only playback breaks, because yt-dlp is dynamically linked and keeps working — which makes it look like a bug in the bot rather than the image.
+- **`FFMPEG_BIN` must keep pointing the container at the distro ffmpeg.** `ffmpeg-static`'s binary is statically linked against a much older glibc and cannot resolve hostnames in this image, failing every lookup with "Failed to resolve hostname: System error". Only playback breaks — yt-dlp is dynamically linked and keeps working — so it looks like a bug in the bot rather than the image.
 - This is a **public** repository. Don't reference private infrastructure repositories, internal hostnames, or machine names in code, comments, or docs.
 
 ## Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ kubectl kustomize kustomize/overlays/pr
 
 - **`kustomize/overlays/*/{bot,database}/sealed-secret.yaml` contain real committed ciphertext.** Never overwrite them with placeholders to make a render succeed, and never delete them. SealedSecret ciphertext is bound to its namespace *and* name, so it cannot be regenerated from this repo.
 - **`NPM_VERSION` in the Dockerfile must match the npm that generated `package-lock.json`.** A mismatch makes `npm ci` fail on lockfile contents that are actually fine.
+- **`FFMPEG_BIN` must keep pointing the container at the distro ffmpeg.** `ffmpeg-static`'s binary is statically linked against a much older glibc, and static glibc cannot resolve hostnames without matching NSS modules to dlopen, so in-cluster it fails every lookup with "Failed to resolve hostname: System error". Only playback breaks, because yt-dlp is dynamically linked and keeps working — which makes it look like a bug in the bot rather than the image.
 - This is a **public** repository. Don't reference private infrastructure repositories, internal hostnames, or machine names in code, comments, or docs.
 
 ## Style

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ ARG YTDLP_VERSION=2026.07.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \
+    ffmpeg \
     python3 \
     python3-pip \
   && apt-get clean \
@@ -83,12 +84,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && pip3 install --no-cache-dir --break-system-packages "yt-dlp==${YTDLP_VERSION}" \
   # Fail the build loudly if any of these assumptions break.
   && test -x /usr/bin/tini \
+  # Asserted by path, not by name: FFMPEG_BIN below hard-codes this location.
+  && test -x /usr/bin/ffmpeg \
   && node --version \
-  && yt-dlp --version
+  && yt-dlp --version \
+  && ffmpeg -version
 
 # Point youtube-dl-exec at the pinned system yt-dlp rather than the copy it bundles,
 # so the extractor is upgraded by rebuilding this image, not by a package release.
 ENV YTDLP_PATH=/usr/local/bin/yt-dlp
+
+# Same idea for ffmpeg, but this one is mandatory, not a preference. ffmpeg-static
+# ships a statically linked glibc build; static glibc has to dlopen NSS to resolve
+# hostnames, and this image's glibc is far newer than the one it was built against,
+# so every lookup fails with "Failed to resolve hostname: System error" and playback
+# silently yields no audio. The distro build is dynamically linked and resolves fine.
+# ffmpeg-static stays a dependency because it is what local development uses.
+ENV FFMPEG_BIN=/usr/bin/ffmpeg
 
 WORKDIR /home/node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && pip3 install --no-cache-dir --break-system-packages "yt-dlp==${YTDLP_VERSION}" \
   # Fail the build loudly if any of these assumptions break.
   && test -x /usr/bin/tini \
-  # Asserted by path, not by name: FFMPEG_BIN below hard-codes this location.
   && test -x /usr/bin/ffmpeg \
   && node --version \
   && yt-dlp --version \
@@ -94,12 +93,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # so the extractor is upgraded by rebuilding this image, not by a package release.
 ENV YTDLP_PATH=/usr/local/bin/yt-dlp
 
-# Same idea for ffmpeg, but this one is mandatory, not a preference. ffmpeg-static
-# ships a statically linked glibc build; static glibc has to dlopen NSS to resolve
-# hostnames, and this image's glibc is far newer than the one it was built against,
-# so every lookup fails with "Failed to resolve hostname: System error" and playback
-# silently yields no audio. The distro build is dynamically linked and resolves fine.
-# ffmpeg-static stays a dependency because it is what local development uses.
+# ffmpeg-static's binary is statically linked against a much older glibc, and static
+# glibc cannot resolve hostnames here, so every stream fails. The distro build is
+# dynamic and works; ffmpeg-static stays a dependency for local development.
 ENV FFMPEG_BIN=/usr/bin/ffmpeg
 
 WORKDIR /home/node

--- a/src/classes/voice.ts
+++ b/src/classes/voice.ts
@@ -13,6 +13,7 @@ import {
 } from '@discordjs/voice';
 import { FFmpeg } from 'prism-media';
 import { resolveStream, StreamTarget, TrackInfo } from '@modules/ytdlp';
+import { VOID } from '@modules/utils';
 
 /**
  * ffmpeg flags that have to precede -i because they configure the input protocol.
@@ -24,12 +25,10 @@ const FFMPEG_INPUT_ARGS = [
     '-reconnect_streamed', '1',
     '-reconnect_delay_max', '5',
     '-analyzeduration', '0',
-    // Not 0: a silenced ffmpeg turns every playback failure into an unexplained
-    // "End of queue", which is exactly how a broken stream URL went undiagnosed.
+    // Not 0: silencing ffmpeg turns any playback failure into an unexplained "End of queue".
     '-loglevel', 'error',
 ];
 
-/** Enough of ffmpeg's stderr to name the failure, without logging a whole stream. */
 const FFMPEG_STDERR_TAIL = 2000;
 
 /**
@@ -49,10 +48,8 @@ function createOpusStream(source: StreamTarget) {
         ],
     });
 
-    // prism-media forwards stdout and never inspects the exit code, so an ffmpeg that
-    // dies on startup closes the pipe with zero bytes -- indistinguishable from a song
-    // that played to the end. The player goes straight to Idle and the queue silently
-    // "ends" with nothing logged. Watch the process ourselves so that never recurs.
+    // prism-media never inspects the exit code, so a dead ffmpeg closes stdout with zero
+    // bytes and is indistinguishable from a song that played out.
     const child = stream.process;
     let stderr = '';
     child.stderr?.on('data', (chunk: Buffer) => {
@@ -271,13 +268,15 @@ export class GuildVoice {
         const connection = this.join(voiceChannel);
         connection.subscribe(this.player);
 
-        this.player.on('error', async err => {
-            await this.textChannel.send({
+        // Deliberately not async: a throw here is an unhandled rejection that takes the
+        // shard down. The player goes Idle after an error, so the next song follows anyway.
+        this.player.on('error', err => {
+            console.error(err);
+            this.textChannel.send({
                 content:
                     'Something bad happened while I was playing...\n' +
                     'Sorry! I will continue to play the next song.',
-            });
-            throw err;
+            }).catch(VOID);
         });
         connection.on(VoiceConnectionStatus.Ready, async () => {
             // Get latest voice channel info

--- a/src/classes/voice.ts
+++ b/src/classes/voice.ts
@@ -24,8 +24,13 @@ const FFMPEG_INPUT_ARGS = [
     '-reconnect_streamed', '1',
     '-reconnect_delay_max', '5',
     '-analyzeduration', '0',
-    '-loglevel', '0',
+    // Not 0: a silenced ffmpeg turns every playback failure into an unexplained
+    // "End of queue", which is exactly how a broken stream URL went undiagnosed.
+    '-loglevel', 'error',
 ];
+
+/** Enough of ffmpeg's stderr to name the failure, without logging a whole stream. */
+const FFMPEG_STDERR_TAIL = 2000;
 
 /**
  * Wraps a resolved stream in Ogg so @discordjs/voice can demux straight to Opus.
@@ -34,7 +39,7 @@ function createOpusStream(source: StreamTarget) {
     const codecArgs = source.acodec === 'opus'
         ? ['-c:a', 'copy']
         : ['-c:a', 'libopus', '-b:a', '128k', '-ar', '48000', '-ac', '2'];
-    return new FFmpeg({
+    const stream = new FFmpeg({
         args: [
             ...FFMPEG_INPUT_ARGS,
             '-i', source.streamUrl,
@@ -43,6 +48,22 @@ function createOpusStream(source: StreamTarget) {
             '-f', 'opus',
         ],
     });
+
+    // prism-media forwards stdout and never inspects the exit code, so an ffmpeg that
+    // dies on startup closes the pipe with zero bytes -- indistinguishable from a song
+    // that played to the end. The player goes straight to Idle and the queue silently
+    // "ends" with nothing logged. Watch the process ourselves so that never recurs.
+    const child = stream.process;
+    let stderr = '';
+    child.stderr?.on('data', (chunk: Buffer) => {
+        stderr = (stderr + chunk.toString()).slice(-FFMPEG_STDERR_TAIL);
+    });
+    child.once('close', (code, signal) => {
+        // Skipping or stopping SIGKILLs ffmpeg, and prism clears .process first.
+        if (signal || stream.process !== child) return;
+        if (code) console.error(`ffmpeg exited ${code} playing ${source.webpageUrl}\n${stderr.trim()}`);
+    });
+    return stream;
 }
 
 export const enum LoopType {


### PR DESCRIPTION
## Symptom

A song is added and announced, then the queue immediately reports `End of queue` — with an empty log.

```
🎶 Now Playing: Ayaka Dancing In The River Cutscene  02:02 left
:barempty: … 00:00 / 02:02
End of queue.
```

## Root cause

`ffmpeg-static` ships a **statically linked glibc** binary. Static glibc has to `dlopen` NSS modules to resolve hostnames, and the bundled build targets glibc 2.28 (`gcc 8 (Debian 8.3.0-6)`) while the image is Ubuntu 24.04 / glibc 2.39. In-cluster, ffmpeg fails **every** DNS lookup:

```
[tcp @ …] Failed to resolve hostname rr2---sn-gvbxgn-tt1ed.googlevideo.com: System error
[in#0 @ …] Error opening input: Input/output error
```

Verified against the running prod pod:

| check | result |
|---|---|
| pod resolver (`getent hosts youtube.com`) | ✅ resolves |
| dynamically-linked `curl` on the same CDN URL | ✅ HTTP 206, 200 001 bytes |
| static ffmpeg on that CDN URL | ❌ cannot resolve |
| static ffmpeg on `example.com` | ❌ cannot resolve — it's every host, not YouTube |

yt-dlp is Python and dynamically linked, so it kept working. That's why metadata (title, `02:02`) was correct and only playback broke — it looked like a bot bug rather than an image bug.

**Why the log was empty.** Two things hid it: `-loglevel 0` discarded ffmpeg's diagnosis, and prism-media forwards only stdout and never inspects the exit code ([`FFmpeg.js:69`](https://github.com/amishshah/prism-media/blob/master/src/core/FFmpeg.js)). An ffmpeg that dies on startup closes the pipe with zero bytes, which is indistinguishable from a song that played to the end — so the player went straight to `Idle` and the queue quietly "ended". It even reported `playing` first, which is why *Now Playing* posted at `00:00`.

## Changes

- **`Dockerfile`** — install the distro ffmpeg and point `FFMPEG_BIN` at it, mirroring the `YTDLP_PATH` override already used for yt-dlp. `ffmpeg-static` stays a dependency because it's what local development uses. The build asserts `test -x /usr/bin/ffmpeg`, by path, since `FFMPEG_BIN` hard-codes that location.
- **`src/classes/voice.ts`** — `-loglevel error`, capture ffmpeg's stderr tail, and log on non-zero exit. Guarded so a deliberate teardown (skip/stop, which SIGKILLs ffmpeg) stays quiet.
- **`src/classes/voice.ts`** — the player's `error` listener was `async` and ended in `throw err`, so it rejected with nothing to catch it and killed the shard on any player error. Now logs instead; the player goes `Idle` after an error, so the next song follows regardless. This was latent before, but surfacing ffmpeg failures would have started reaching it.
- **`CLAUDE.md`** — record the trap under "Things that are easy to break".

## Verification

- `tsc --noEmit` and `npm run lint` both clean.
- ffmpeg failure logging fires on a real failure and stays quiet on `destroy()`, tested deterministically.
- The listener fix confirmed both ways: the old shape exits `1` on a player error, the new shape logs and survives.
- **Not verified: the image build** — the Docker daemon wasn't running locally. The `test -x /usr/bin/ffmpeg` assertion makes a wrong path fail the build loudly rather than ship. Worth watching the first build.

## Notes

- `package-lock.json` was locally modified before this work, but that was an artifact of npm 10.8.3; npm 11.5.1 (the pinned `NPM_VERSION`) reproduces the committed lockfile exactly, so it is deliberately **not** included — committing it would trip the `npm ci` mismatch CLAUDE.md warns about.
- Seen locally while testing: an intermittent **403** on `c=ANDROID_VR` format URLs, unrelated to this bug. It will now appear in the logs instead of silently ending the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NCZgHGPPxioxjGrf8WkuS
