### PR TITLE
fix(music): pin the yt-dlp player client for signed in requests

### DIFF
--- a/src/modules/ytdlp.ts
+++ b/src/modules/ytdlp.ts
@@ -76,10 +76,12 @@ const COOKIES_PATH = (() => {
  */
 function withCookies(flags: Record<string, unknown>): Record<string, unknown> {
     // Inject JS runtimes so it can solve JS challenges, only if there is a cookie included.
+    // https://github.com/yt-dlp/yt-dlp/issues/17389
     return COOKIES_PATH ? {
         ...flags,
         cookies: COOKIES_PATH,
         jsRuntimes: 'node',
+        extractorArgs: 'youtube:player_client=default,web_embedded',
     } : flags;
 }
 


### PR DESCRIPTION
Playback is currently broken in prod. Two lines.

## Cause

yt-dlp routes requests carrying cookies to the `tv_downgraded` player client, which currently answers every player request with `The page needs to be reloaded` ([yt-dlp#17389](https://github.com/yt-dlp/yt-dlp/issues/17389)). Anonymous requests use a different client and are unaffected — which is why this only started once a cookie jar was in place, and why it looked like a credential problem rather than an upstream one.

## Why it was hard to read

- **`--flat-playlist` never reaches the player endpoint.** Searches and playlists kept resolving normally, so the queue filled with correct titles, durations and thumbnails. Only `resolveStream` and single-video lookups failed, which made it look like a playback bug rather than an extraction one.
- **Some videos degrade instead of erroring.** They come back with an HLS-only format set, the selector's `best` fallback picks a combined video+audio manifest, and ffmpeg cannot fetch its segments because it holds none of the session's credentials. That surfaced as `ffmpeg exited 183` — `AVERROR_INVALIDDATA` — pointing at ffmpeg rather than at yt-dlp.
- **Failed resolves spin.** `playNextSong` recurses to the next song on a failed resolve, and `LoopType.all` refills the queue as it empties, so the queue cycles without ever reaching playback. That's the "10 minutes to load the next song" symptom, and it spawns a yt-dlp process per turn.

Only the first is fixed here. The recursion has no bound and the selector can still choose a manifest — both are real and worth addressing, but they are pre-existing and separate from getting playback working again.

## Scope

Pinned inside `withCookies`, so it applies only to cookied calls and the anonymous path is untouched.

## Verification

Checked against the real extractor rather than assumed: three videos, with and without a jar, all resolve format `251` opus over https. `extractorArgs` was confirmed to map to `--extractor-args` by calling it through `youtube-dl-exec` itself, since a wrong flag name would break every yt-dlp call in the module.

`npx tsc --noEmit` and `npm run lint` clean. No dependency changes.

**Not verified:** age-gated playback, as no authenticated cookie jar was available to test with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBqbVjFJzYJKwNSHjRahvF
