### PR TITLE
fix(commands): dispatch subcommand groups with their own `this`

### DIFF
--- a/src/classes/commands.ts
+++ b/src/classes/commands.ts
@@ -240,41 +240,42 @@ export class SlashCommandWithSubcommand<CacheType extends NodePgJsonValue = neve
     subcommands: Map<string, SlashSubcommandGroup | SlashSubcommand>;
 
     constructor(options: SlashCommandWithSubcommandOptions<CacheType>) {
+        type Self = SlashCommandWithSubcommand<CacheType>;
         super(options);
         this.subcommands = new Map();
         this.type = CommandType.SLASH_COMMAND_WITH_SUBCOMMAND;
         // Different from SlashCommand without subcommands in the sense that we handle the execute
         // and all other functions automatically so only one definition is required in the lowest subcommand level.
-        this.execute = async function (i) {
+        this.execute = (async function (this: Self, i: ChatInputCommandInteraction) {
             if (this.subcommands.size === 0) throw new Error(`execute: NO SUBCOMMANDS FOR ${this.data.name}`);
             const subcommand = this.subcommands.get(
                 i.options.getSubcommandGroup(false) ??
                 i.options.getSubcommand()!,
             );
             if (!subcommand) throw new Error(`execute: SUBCOMMAND FOR ${this.data.name} NOT FOUND`);
-            return subcommand.execute.bind(this)(i);
-        };
-        this.buttonReact = async function (i) {
+            return subcommand.execute(i);
+        }).bind(this);
+        this.buttonReact = (async function (this: Self, i: ButtonInteraction) {
             if (this.subcommands.size === 0) throw new Error(`buttonReact: NO SUBCOMMANDS FOR ${this.data.name}`);
             const subcommandName = await options.buttonReactGetter?.bind(this)(i);
             const subcommand = this.subcommands.get(subcommandName ?? '');
             if (!subcommand) throw new Error(`buttonReact: SUBCOMMAND FOR ${this.data.name} NOT FOUND`);
             return subcommand.buttonReact(i);
-        };
-        this.menuReact = async function (i) {
+        }).bind(this);
+        this.menuReact = (async function (this: Self, i: AnySelectMenuInteraction) {
             if (this.subcommands.size === 0) throw new Error(`menuReact: NO SUBCOMMANDS FOR ${this.data.name}`);
             const subcommandName = await options.menuReactGetter?.bind(this)(i);
             const subcommand = this.subcommands.get(subcommandName ?? '');
             if (!subcommand) throw new Error(`menuReact: SUBCOMMAND FOR ${this.data.name} NOT FOUND`);
-            return subcommand.menuReact.bind(this)(i);
-        };
-        this.textInput = async function (i) {
+            return subcommand.menuReact(i);
+        }).bind(this);
+        this.textInput = (async function (this: Self, i: ModalSubmitInteraction) {
             if (this.subcommands.size === 0) throw new Error(`textInput: NO SUBCOMMANDS FOR ${this.data.name}`);
             const subcommandName = await options.textInputGetter?.bind(this)(i);
             const subcommand = this.subcommands.get(subcommandName ?? '');
             if (!subcommand) throw new Error(`textInput: SUBCOMMAND FOR ${this.data.name} NOT FOUND`);
-            return subcommand.textInput.bind(this)(i);
-        };
+            return subcommand.textInput(i);
+        }).bind(this);
         for (const subcommand of options.subcommands ?? []) {
             if (subcommand.isSlashSubcommand()) this.addSubcommand(subcommand);
             else this.addSubcommandGroup(subcommand);
@@ -303,38 +304,39 @@ export class SlashSubcommandGroup<CacheType extends NodePgJsonValue = never> ext
     subcommands: Map<string, SlashSubcommand>;
 
     constructor(options: SlashSubcommandGroupOptions<CacheType>) {
+        type Self = SlashSubcommandGroup<CacheType>;
         super(options);
         this.subcommands = new Map();
         this.type = CommandType.SLASH_SUBCOMMAND_GROUP;
         // Different from SlashCommand without subcommands in the sense that we handle the execute
         // and all other functions automatically so only one definition is required in the lowest subcommand level.
-        this.execute = async function (i) {
+        this.execute = (async function (this: Self, i: ChatInputCommandInteraction) {
             if (this.subcommands.size === 0) throw new Error(`execute: NO SUBCOMMANDS IN GROUP ${this.data.name}`);
             const subcommand = this.subcommands.get(i.options.getSubcommand()!);
             if (!subcommand) throw new Error(`execute: SUBCOMMAND IN GROUP ${this.data.name} NOT FOUND`);
-            return subcommand.execute.bind(this)(i);
-        };
-        this.buttonReact = async function (i) {
+            return subcommand.execute(i);
+        }).bind(this);
+        this.buttonReact = (async function (this: Self, i: ButtonInteraction) {
             if (this.subcommands.size === 0) throw new Error(`buttonReact: NO SUBCOMMANDS IN GROUP ${this.data.name}`);
             const subcommandName = await options.buttonReactGetter?.bind(this)(i);
             const subcommand = this.subcommands.get(subcommandName ?? '');
             if (!subcommand) throw new Error(`buttonReact: SUBCOMMAND IN GROUP ${this.data.name} NOT FOUND`);
-            return subcommand.buttonReact.bind(this)(i);
-        };
-        this.menuReact = async function (i) {
+            return subcommand.buttonReact(i);
+        }).bind(this);
+        this.menuReact = (async function (this: Self, i: AnySelectMenuInteraction) {
             if (this.subcommands.size === 0) throw new Error(`menuReact: NO SUBCOMMANDS IN GROUP ${this.data.name}`);
             const subcommandName = await options.menuReactGetter?.bind(this)(i);
             const subcommand = this.subcommands.get(subcommandName ?? '');
             if (!subcommand) throw new Error(`menuReact: SUBCOMMAND IN GROUP ${this.data.name} NOT FOUND`);
-            return subcommand.menuReact.bind(this)(i);
-        };
-        this.textInput = async function (i) {
+            return subcommand.menuReact(i);
+        }).bind(this);
+        this.textInput = (async function (this: Self, i: ModalSubmitInteraction) {
             if (this.subcommands.size === 0) throw new Error(`textInput: NO SUBCOMMANDS IN GROUP ${this.data.name}`);
             const subcommandName = await options.textInputGetter?.bind(this)(i);
             const subcommand = this.subcommands.get(subcommandName ?? '');
             if (!subcommand) throw new Error(`textInput: SUBCOMMAND IN GROUP ${this.data.name} NOT FOUND`);
-            return subcommand.textInput.bind(this)(i);
-        };
+            return subcommand.textInput(i);
+        }).bind(this);
         for (const subcommand of options.subcommands ?? []) {
             this.addSubcommand(subcommand);
         }

--- a/src/commands/music_commands.ts
+++ b/src/commands/music_commands.ts
@@ -916,7 +916,7 @@ const remove_song = new SlashSubcommand({
 
     long_description:
         'Removes a song at a certain index. Cannot be used to skip the current playing song\n' +
-        'Use {/skip} to skip the current song instead. Only hosts may use this command.\n\n' +
+        'Use {/music skip} to skip the current song instead. Only hosts may use this command.\n\n' +
         'Usage: `/music remove song index: <index>`\n\n' +
         '__**Options**__\n' +
         '*index:* The index of the song in the queue. See {/music queue} (Required)\n\n' +
@@ -940,7 +940,7 @@ const remove_song = new SlashSubcommand({
                 content: `There are only ${guildVoice.fullQueue.length} songs.`,
             }).then(Utils.VOID);
         } else if (res === 0) {
-            const skip_cmd = await Utils.get_rich_cmd('skip', interaction.client);
+            const skip_cmd = await Utils.get_rich_cmd('music skip', interaction.client);
             return interaction.editReply({
                 content: `Song at index ${idx + 1} is currently playing. Use ${skip_cmd} instead.`,
             }).then(Utils.VOID);


### PR DESCRIPTION
## Problem

`/music remove song` has never been reachable. It throws before the handler runs:

```
Error: execute: SUBCOMMAND IN GROUP music NOT FOUND
    at SlashSubcommandGroup.execute (src/classes/commands.ts:314:36)
    at SlashCommandWithSubcommand.execute (src/classes/commands.ts:255:49)
```

The command body and `GuildVoice.removeSong` were both already complete and correct. The defect was in dispatch.

## Root cause

`SlashCommandWithSubcommand.execute` called the child with the *parent's* `this`:

```ts
return subcommand.execute.bind(this)(i);   // `this` === the `music` command
```

The group's dispatcher then read `this.subcommands` and got music's map (`join, leave, …, remove, vote`) instead of its own (`{song}`). `getSubcommand()` returns `song`, the lookup misses, and it throws.

The error message is the proof: it interpolates `${this.data.name}` and printed `music`, not `remove`.

**Same cause, silent symptom:** `/music vote skip` did not throw. The `vote` group looked up `skip` in music's map, which *hits* — on the real top-level `skip` leaf. A vote-skip was skipping the song outright rather than reaching its "not implemented yet" stub.

## Fix

The bind was never needed. Leaf handlers are already bound in the `SlashCommand` base constructor, so the call-site binds were no-ops on leaves and only ever corrupted groups.

Bind the synthesized dispatchers on `SlashCommandWithSubcommand` and `SlashSubcommandGroup` in their own constructors — where every other handler in the hierarchy is bound, and what CLAUDE.md already documents — and drop `.bind(this)` from all seven dispatch call sites. (`commands.ts:262` already omitted it, so the call sites were inconsistent with each other too.)

Also fixes two `get_rich_cmd` lookups in `remove song` that passed `skip` as a *top-level* command name. No such command exists — it is `/music skip` — so both fell through to the plain-text fallback and rendered `` `/skip` `` instead of a clickable mention:

- `music_commands.ts:943` — the "that song is currently playing, use X instead" reply
- `music_commands.ts:919` — `{/skip}` in `long_description`, expanded by `help_command.ts:352`

## Verification

No test suite in this repo, so: `tsc --noEmit` clean, `npm run lint` clean.

Beyond that, I drove the dispatch directly against a built `dist/`. Against the **pre-fix** code:

```
FAIL  /music remove song   THREW: execute: SUBCOMMAND IN GROUP music NOT FOUND
FAIL  /music vote skip     got top/skip   (expected vote/skip)
PASS  /music skip
```

The reported error, verbatim, plus the predicted silent mis-route. Against this branch all cases pass, including a deliberately detached `music.execute` — which fails without the constructor binding.

Still worth a manual pass in a test guild: `/music remove song` on a queued index, on the playing index, and out of range; `/music vote skip` reaching its stub; `/help music remove song` rendering a clickable mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBqbVjFJzYJKwNSHjRahvF